### PR TITLE
python-pip renamed to python2-pip for RedHat families

### DIFF
--- a/napalm_install/map.jinja
+++ b/napalm_install/map.jinja
@@ -8,11 +8,11 @@
         'pluribus': ['python-pip', 'libssl-dev', 'libssl-dev', 'libffi-dev', 'python-dev', 'python-cffi']
     },
     'RedHat': {
-        'ios': ['python-pip', 'python-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel'],
-        'vyos': ['python-pip', 'python-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel'],
-        'junos': ['python-pip', 'python-devel', 'libxml2-devel', 'libxslt-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel'],
-        'iosxr': ['python-pip', 'python-devel', 'libxml2-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel'],
-        'panos': ['python-pip', 'python-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel'],
-        'pluribus': ['python-pip', 'python-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel']
+        'ios': ['python2-pip', 'python-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel'],
+        'vyos': ['python2-pip', 'python-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel'],
+        'junos': ['python2-pip', 'python-devel', 'libxml2-devel', 'libxslt-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel'],
+        'iosxr': ['python2-pip', 'python-devel', 'libxml2-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel'],
+        'panos': ['python2-pip', 'python-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel'],
+        'pluribus': ['python2-pip', 'python-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel']
     }
 }, grain='os_family', merge=salt['pillar.get']('napalm')) %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,4 @@
 napalm:
   install:
-    - napalm_ios
+    - napalm-ios
     - napalm-panos


### PR DESCRIPTION
As title suggest, RedHat renamed their python-pip package to python2-pip. In addition, pillar.example had a minor typo. I changed `napalm_ios` to `napalm-ios`.

Result of improper package name:

```
$ salt-call state.sls napalm_install

local:
----------
          ID: install_napalm_iosxr_pkgs
    Function: pkg.installed
      Result: False
     Comment: The following packages failed to install/update: python-pip
              The following packages were already installed: gcc, libxml2-devel, python-devel, openssl, openssl-devel, libffi-devel
     Started: 22:16:30.955701
    Duration: 36257.411 ms
     Changes:   
----------
          ID: napalm-iosxr
    Function: pip.installed
      Result: True
     Comment: Python package napalm-iosxr was already installed
              All packages were successfully installed
     Started: 22:17:07.368161
    Duration: 692.242 ms
     Changes:   
----------
          ID: install_napalm_ios_pkgs
    Function: pkg.installed
      Result: False
     Comment: The following packages failed to install/update: python-pip
              The following packages were already installed: gcc, python-devel, openssl, openssl-devel, libffi-devel
     Started: 22:17:08.060630
    Duration: 27883.845 ms
     Changes:   
----------
          ID: napalm-ios
    Function: pip.installed
      Result: True
     Comment: Python package napalm-ios was already installed
              All packages were successfully installed
     Started: 22:17:35.944687
    Duration: 688.649 ms
     Changes:   

Summary for local
------------
Succeeded: 2
Failed:    2
------------
Total states run:     4
Total run time:  65.522 s
```