### PR TITLE
Altered filter_by merge dest to avoid other napalm pillar data

### DIFF
--- a/napalm_install/map.jinja
+++ b/napalm_install/map.jinja
@@ -15,4 +15,4 @@
         'panos': ['python2-pip', 'python-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel'],
         'pluribus': ['python2-pip', 'python-devel', 'gcc', 'openssl', 'openssl-devel', 'libffi-devel']
     }
-}, grain='os_family', merge=salt['pillar.get']('napalm')) %}
+}, grain='os_family', merge=salt['pillar.get']('napalm:packages')) %}


### PR DESCRIPTION
Was attempting to install all napalm drivers using the following pillar.sls:

```
napalm:
  install:
    - napalm
```

This resulted in package 'napalm' being added to the pkg.installed list which causes and error in that state.

Using filter_by `merge=salt['pillar.get']('napalm')` in map.jinja picked up the napalm:install pillar data into the 'map' dictionary. When init.sls was looping through the map dictionary, it added 'napalm' under pkg.installed state.


```
{
'iosxr': ['python-pip', 'libxml2-dev', 'libssl-dev', 'libssl-dev', 'libffi-dev', 'python-dev', 'python-cffi'], 
'ios': ['python-pip', 'libssl-dev', 'libssl-dev', 'libffi-dev', 'python-dev', 'python-cffi'], 
'vyos': ['python-pip', 'libssl-dev', 'libssl-dev', 'libffi-dev', 'python-dev', 'python-cffi'], 
'junos': ['python-pip', 'libxml2-dev', 'libxslt1-dev', 'libssl-dev', 'libffi-dev', 'python-dev', 'python-cffi'], 
'pluribus': ['python-pip', 'libssl-dev', 'libssl-dev', 'libffi-dev', 'python-dev', 'python-cffi'],
'install': ['napalm'], <--
'panos': ['python-pip', 'libssl-dev', 'libssl-dev', 'libffi-dev', 'python-dev', 'python-cffi']
}
```
```

local:
----------
          ID: install_napalm_pkgs
    Function: pkg.installed
      Result: False
     Comment: Problem encountered installing package(s). Additional info follows:
              
              errors:
                  - Running scope as unit run-rb482a6d90dbe441c8d9db40a7ef3a449.scope.
                    E: Unable to locate package napalm
     Started: 02:22:12.699187
    Duration: 8516.143 ms
     Changes:   
----------
          ID: napalm
    Function: pip.installed
      Result: True
     Comment: Python package napalm was already installed
              All packages were successfully installed
     Started: 02:22:21.418367
    Duration: 956.623 ms
     Changes:   

```

By adjusting the map dictionary merge to napalm:packages it avoids any other values set in the napalm pillar and doesn't impact the rest of the state.

Another option would be to add `if pkg != 'napalm'` to the line 12 for loop in init.sls, but I felt this dictionary separation was cleaner.